### PR TITLE
Explain Wayland clipboard via Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # clip-to-chat
+
+A small utility that reads the current Wayland clipboard and asks the Gemini LLM to explain it. The response is shown in a separate window.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ensure `wl-paste` is available (part of [wl-clipboard](https://github.com/bugaevc/wl-clipboard)).
+3. Set your Gemini API key:
+   ```bash
+   export GEMINI_KEY="your_api_key_here"
+   ```
+4. Run the script:
+   ```bash
+   python clip_to_chat.py
+   ```
+
+This will open a window containing the model's explanation of the clipboard contents.

--- a/clip_to_chat.py
+++ b/clip_to_chat.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Send Wayland clipboard content to Gemini and show explanation."""
+
+import os
+import sys
+import subprocess
+
+import requests
+import tkinter as tk
+
+
+def get_clipboard() -> str:
+    """Return current Wayland clipboard text using wl-paste."""
+    result = subprocess.run(
+        ["wl-paste"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def ask_gemini(text: str, api_key: str) -> str:
+    """Ask Gemini to explain the provided text."""
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/"
+        "models/gemini-pro:generateContent"
+    )
+    headers = {"Content-Type": "application/json"}
+    prompt = f"Explain the following text:\n\n{text}"
+    payload = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": prompt}],
+            }
+        ]
+    }
+    response = requests.post(url, headers=headers, params={"key": api_key}, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return data["candidates"][0]["content"]["parts"][0]["text"]
+
+
+def show_text(text: str) -> None:
+    """Display text in a simple Tkinter window."""
+    root = tk.Tk()
+    root.title("Gemini Explanation")
+    widget = tk.Text(root, wrap="word")
+    widget.insert("1.0", text)
+    widget.config(state="disabled")
+    widget.pack(expand=True, fill="both")
+    root.mainloop()
+
+
+def main() -> int:
+    api_key = os.getenv("GEMINI_KEY")
+    if not api_key:
+        print("GEMINI_KEY environment variable not set", file=sys.stderr)
+        return 1
+    try:
+        clip = get_clipboard().strip()
+    except subprocess.CalledProcessError as err:
+        print(f"Failed to read clipboard: {err.stderr}", file=sys.stderr)
+        return 1
+    try:
+        explanation = ask_gemini(clip, api_key)
+    except requests.RequestException as err:
+        print(f"Gemini request failed: {err}", file=sys.stderr)
+        return 1
+    show_text(explanation)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add Python utility to send Wayland clipboard content to Gemini for an explanation
- document usage and required dependencies

## Testing
- `python -m py_compile clip_to_chat.py`
- `GEMINI_KEY=abc python clip_to_chat.py` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_689462d40bb88331b102134c1ca9f8ba